### PR TITLE
Purge brokers wsl

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1177,32 +1177,9 @@ static void rd_kafka_destroy_internal(rd_kafka_t *rk) {
                 rd_kafka_wrlock(rk);
         }
 
-        /* Decommission brokers.
-         * Broker thread holds a refcount and detects when broker refcounts
-         * reaches 1 and then decommissions itself. */
+        /* Decommission brokers. */
         TAILQ_FOREACH_SAFE(rkb, &rk->rk_brokers, rkb_link, rkb_tmp) {
-                /* Add broker's thread to wait_thrds list for later joining */
-                thrd  = rd_malloc(sizeof(*thrd));
-                *thrd = rkb->rkb_thread;
-                rd_list_add(&wait_thrds, thrd);
-                rd_kafka_wrunlock(rk);
-
-                rd_kafka_dbg(rk, BROKER, "DESTROY", "Sending TERMINATE to %s",
-                             rd_kafka_broker_name(rkb));
-                /* Send op to trigger queue/io wake-up.
-                 * The op itself is (likely) ignored by the broker thread. */
-                rd_kafka_q_enq(rkb->rkb_ops,
-                               rd_kafka_op_new(RD_KAFKA_OP_TERMINATE));
-
-#ifndef _WIN32
-                /* Interrupt IO threads to speed up termination. */
-                if (rk->rk_conf.term_sig)
-                        pthread_kill(rkb->rkb_thread, rk->rk_conf.term_sig);
-#endif
-
-                rd_kafka_broker_destroy(rkb);
-
-                rd_kafka_wrlock(rk);
+                rd_kafka_broker_decommission(rk, rkb, &wait_thrds);
         }
 
         if (rk->rk_clusterid) {

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5236,6 +5236,8 @@ void rd_kafka_group_list_destroy(const struct rd_kafka_group_list *grplist);
 RD_EXPORT
 int rd_kafka_brokers_add(rd_kafka_t *rk, const char *brokerlist);
 
+RD_EXPORT
+int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp);
 
 
 /**

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -6037,6 +6037,57 @@ int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp) {
 }
 
 /**
+ * @brief Decommission a broker.
+ *
+ * @param rk Client instance.
+ * @param rkb Broker to decommission.
+ * @param wait_thrds Add the broker's thread to this list if not NULL.
+ *
+ * @locks rd_kafka_wrlock() is dropped and reacquired.
+ *
+ * Broker threads hold a refcount and detect when it reaches 1 and then
+ * decommissions itself. Callers can wait for this to happen by calling
+ * thrd_join() on elements of \p wait_thrds. Callers are responsible for
+ * managing the creation and destruction of \p wait_thrds which can be NULL.
+ */
+void rd_kafka_broker_decommission(rd_kafka_t *rk,
+                                  rd_kafka_broker_t *rkb,
+                                  rd_list_t *wait_thrds) {
+
+        if (rkb->termination_in_progress)
+                return;
+
+        rkb->termination_in_progress = rd_true;
+
+        /* Add broker's thread to wait_thrds list for later joining */
+        if (wait_thrds) {
+                thrd_t *thrd = rd_malloc(sizeof(*thrd));
+                *thrd        = rkb->rkb_thread;
+
+                rd_list_add(wait_thrds, thrd);
+        }
+
+        rd_kafka_wrunlock(rk);
+
+        rd_kafka_dbg(rk, BROKER, "DESTROY", "Sending TERMINATE to %s",
+                     rd_kafka_broker_name(rkb));
+
+        /* Send op to trigger queue/io wake-up.
+         * The op itself is (likely) ignored by the broker thread. */
+        rd_kafka_q_enq(rkb->rkb_ops, rd_kafka_op_new(RD_KAFKA_OP_TERMINATE));
+
+#ifndef _WIN32
+        /* Interrupt IO threads to speed up termination. */
+        if (rk->rk_conf.term_sig)
+                pthread_kill(rkb->rkb_thread, rk->rk_conf.term_sig);
+#endif
+
+        rd_kafka_broker_destroy(rkb);
+
+        rd_kafka_wrlock(rk);
+}
+
+/**
  * @name Unit tests
  * @{
  *

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2136,7 +2136,7 @@ rd_kafka_broker_reconnect_backoff(const rd_kafka_broker_t *rkb, rd_ts_t now) {
 static int rd_ut_reconnect_backoff(void) {
         rd_kafka_broker_t rkb = RD_ZERO_INIT;
         rd_kafka_conf_t conf  = {.reconnect_backoff_ms     = 10,
-                                .reconnect_backoff_max_ms = 90};
+                                 .reconnect_backoff_max_ms = 90};
         rd_ts_t now           = 1000000;
         int backoff;
 
@@ -5430,12 +5430,6 @@ void rd_kafka_broker_update(rd_kafka_t *rk,
                  * the hostname. */
                 if (strcmp(rkb->rkb_nodename, nodename))
                         needs_update = 1;
-        } else if ((rkb = rd_kafka_broker_find(rk, proto, mdb->host,
-                                               mdb->port))) {
-                /* Broker matched by hostname (but not by nodeid),
-                 * update the nodeid. */
-                needs_update = 1;
-
         } else if ((rkb = rd_kafka_broker_add(rk, RD_KAFKA_LEARNED, proto,
                                               mdb->host, mdb->port, mdb->id))) {
                 rd_kafka_broker_keep(rkb);
@@ -6008,6 +6002,34 @@ void rd_kafka_broker_start_reauth_cb(rd_kafka_timers_t *rkts, void *_rkb) {
         rd_dassert(rkb);
         rko = rd_kafka_op_new(RD_KAFKA_OP_SASL_REAUTH);
         rd_kafka_q_enq(rkb->rkb_ops, rko);
+}
+
+/**
+ * @brief Retrieve and return the learned broker ids.
+ *
+ * @param rk Instance to use.
+ * @param cntp Will be updated to the number of brokers returned.
+ *
+ * @returns a malloc:ed list of int32_t broker ids.
+ */
+int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp) {
+        rd_kafka_broker_t *rkb;
+
+        size_t all_broker_cnt = rd_atomic32_get(&rk->rk_broker_cnt);
+        /* This over-allocates but simplifies the code. */
+        int32_t *ids = malloc(sizeof(*ids) * all_broker_cnt);
+        int32_t *p   = ids;
+
+        *cntp = 0;
+        TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
+                if (rkb->rkb_source != RD_KAFKA_LEARNED)
+                        continue;
+
+                *p++ = rkb->rkb_nodeid;
+                (*cntp)++;
+        }
+
+        return ids;
 }
 
 /**

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -6010,6 +6010,8 @@ void rd_kafka_broker_start_reauth_cb(rd_kafka_timers_t *rkts, void *_rkb) {
  * @param rk Instance to use.
  * @param cntp Will be updated to the number of brokers returned.
  *
+ * @locks_acquired rd_kafka_rdlock()
+ *
  * @returns a malloc:ed list of int32_t broker ids.
  */
 int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp) {
@@ -6021,6 +6023,7 @@ int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp) {
         int32_t *p   = ids;
 
         *cntp = 0;
+        rd_kafka_rdlock(rk);
         TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
                 if (rkb->rkb_source != RD_KAFKA_LEARNED)
                         continue;
@@ -6028,6 +6031,7 @@ int32_t *rd_kafka_broker_get_learned_ids(rd_kafka_t *rk, size_t *cntp) {
                 *p++ = rkb->rkb_nodeid;
                 (*cntp)++;
         }
+        rd_kafka_rdunlock(rk);
 
         return ids;
 }

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -331,6 +331,9 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
 
 
         rd_kafka_timer_t rkb_sasl_reauth_tmr;
+
+        /** True if this broker thread is terminating. Protected by rkb_lock */
+        rd_bool_t termination_in_progress;
 };
 
 #define rd_kafka_broker_keep(rkb) rd_refcnt_add(&(rkb)->rkb_refcnt)
@@ -616,6 +619,10 @@ void rd_kafka_broker_start_reauth_timer(rd_kafka_broker_t *rkb,
                                         int64_t connections_max_reauth_ms);
 
 void rd_kafka_broker_start_reauth_cb(rd_kafka_timers_t *rkts, void *rkb);
+
+void rd_kafka_broker_decommission(rd_kafka_t *rk,
+                                  rd_kafka_broker_t *rkb,
+                                  rd_list_t *wait_thrds);
 
 int unittest_broker(void);
 

--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -2126,6 +2126,30 @@ rd_kafka_mock_broker_set_rack(rd_kafka_mock_cluster_t *mcluster,
             rd_kafka_op_req(mcluster->ops, rko, RD_POLL_INFINITE));
 }
 
+void rd_kafka_mock_broker_set_host_port(rd_kafka_mock_cluster_t *cluster,
+                                        int32_t broker_id,
+                                        const char *host,
+                                        int port) {
+        rd_kafka_mock_broker_t *mrkb;
+
+        mtx_lock(&cluster->lock);
+        TAILQ_FOREACH(mrkb, &cluster->brokers, link) {
+                if (mrkb->id == broker_id) {
+                        rd_kafka_dbg(
+                            cluster->rk, MOCK, "MOCK",
+                            "Broker %" PRId32
+                            ": Setting advertised listener from %s:%d to %s:%d",
+                            broker_id, mrkb->advertised_listener, mrkb->port,
+                            host, port);
+                        rd_snprintf(mrkb->advertised_listener,
+                                    sizeof(mrkb->advertised_listener), "%s",
+                                    host);
+                        mrkb->port = port;
+                }
+        }
+        mtx_unlock(&cluster->lock);
+}
+
 rd_kafka_resp_err_t
 rd_kafka_mock_coordinator_set(rd_kafka_mock_cluster_t *mcluster,
                               const char *key_type,

--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -1510,6 +1510,28 @@ static void rd_kafka_mock_broker_destroy(rd_kafka_mock_broker_t *mrkb) {
 
 
 /**
+ * @brief Decommission a mock broker from a cluster.
+ *
+ * @param mcluster The mock cluster
+ * @param broker_id The id of the broker to remove
+ *
+ * @returns Error value or 0 if no error occurred
+ */
+rd_kafka_resp_err_t
+rd_kafka_mock_broker_decommission(rd_kafka_mock_cluster_t *mcluster,
+                                  int32_t broker_id) {
+        rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_MOCK);
+
+        rko->rko_u.mock.broker_id = broker_id;
+        rko->rko_u.mock.lo        = rd_false;
+        rko->rko_u.mock.cmd       = RD_KAFKA_MOCK_CMD_BROKER_DECOMMISSION;
+
+        return rd_kafka_op_err_destroy(
+            rd_kafka_op_req(mcluster->ops, rko, RD_POLL_INFINITE));
+}
+
+
+/**
  * @brief Starts listening on the mock broker socket.
  *
  * @returns 0 on success or -1 on error (logged).
@@ -2238,6 +2260,10 @@ rd_kafka_mock_broker_cmd(rd_kafka_mock_cluster_t *mcluster,
                         mrkb->rack = NULL;
                 break;
 
+        case RD_KAFKA_MOCK_CMD_BROKER_DECOMMISSION:
+                rd_kafka_mock_broker_destroy(mrkb);
+                break;
+
         default:
                 RD_BUG("Unhandled mock cmd %d", rko->rko_u.mock.cmd);
                 break;
@@ -2384,6 +2410,7 @@ rd_kafka_mock_cluster_cmd(rd_kafka_mock_cluster_t *mcluster,
         case RD_KAFKA_MOCK_CMD_BROKER_SET_UPDOWN:
         case RD_KAFKA_MOCK_CMD_BROKER_SET_RTT:
         case RD_KAFKA_MOCK_CMD_BROKER_SET_RACK:
+        case RD_KAFKA_MOCK_CMD_BROKER_DECOMMISSION:
                 return rd_kafka_mock_brokers_cmd(mcluster, rko);
 
         case RD_KAFKA_MOCK_CMD_COORD_SET:

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -337,6 +337,18 @@ rd_kafka_mock_broker_set_rack(rd_kafka_mock_cluster_t *mcluster,
 
 
 /**
+ * @brief Remove and delete a mock broker from a cluster.
+ *
+ * @param cluster The mock cluster containing the broker
+ * @param broker_id The broker to delete
+ * @returns 0 on success or -1 on error
+ */
+RD_EXPORT int
+rd_kafka_mock_broker_decommission(rd_kafka_mock_cluster_t *cluster,
+                                  int32_t broker_id);
+
+
+/**
  * @brief Explicitly sets the coordinator. If this API is not a standard
  *        hashing scheme will be used.
  *

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -293,6 +293,13 @@ RD_EXPORT rd_kafka_resp_err_t
 rd_kafka_mock_broker_set_down(rd_kafka_mock_cluster_t *mcluster,
                               int32_t broker_id);
 
+RD_EXPORT void
+rd_kafka_mock_broker_set_host_port(rd_kafka_mock_cluster_t *mcluster,
+                                   int32_t broker_id,
+                                   const char *host,
+                                   int port);
+
+
 /**
  * @brief Makes the broker accept connections again.
  *        This does NOT trigger leader change.

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -99,11 +99,12 @@ typedef struct rd_kafka_mock_cgrp_s {
         char *protocol_name;                     /**< Elected protocol name */
         int32_t generation_id;                   /**< Generation Id */
         int session_timeout_ms;                  /**< Session timeout */
-        enum { RD_KAFKA_MOCK_CGRP_STATE_EMPTY,   /* No members */
-               RD_KAFKA_MOCK_CGRP_STATE_JOINING, /* Members are joining */
-               RD_KAFKA_MOCK_CGRP_STATE_SYNCING, /* Syncing assignments */
-               RD_KAFKA_MOCK_CGRP_STATE_REBALANCING, /* Rebalance triggered */
-               RD_KAFKA_MOCK_CGRP_STATE_UP,          /* Group is operational */
+        enum {
+                RD_KAFKA_MOCK_CGRP_STATE_EMPTY,       /* No members */
+                RD_KAFKA_MOCK_CGRP_STATE_JOINING,     /* Members are joining */
+                RD_KAFKA_MOCK_CGRP_STATE_SYNCING,     /* Syncing assignments */
+                RD_KAFKA_MOCK_CGRP_STATE_REBALANCING, /* Rebalance triggered */
+                RD_KAFKA_MOCK_CGRP_STATE_UP,          /* Group is operational */
         } state;                        /**< Consumer group state */
         rd_kafka_timer_t session_tmr;   /**< Session timeout timer */
         rd_kafka_timer_t rebalance_tmr; /**< Rebalance state timer */
@@ -385,7 +386,7 @@ struct rd_kafka_mock_cluster_s {
         struct {
                 rd_kafka_mock_io_handler_t *cb; /**< Callback */
                 void *opaque;                   /**< Callbacks' opaque */
-        } * handlers;
+        } *handlers;
 
         /**< Per-protocol request error stack. */
         rd_kafka_mock_error_stack_head_t errstacks;

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -459,13 +459,14 @@ struct rd_kafka_op_s {
                         struct rd_kafka_admin_worker_cbs *cbs;
 
                         /** Worker state */
-                        enum { RD_KAFKA_ADMIN_STATE_INIT,
-                               RD_KAFKA_ADMIN_STATE_WAIT_BROKER,
-                               RD_KAFKA_ADMIN_STATE_WAIT_CONTROLLER,
-                               RD_KAFKA_ADMIN_STATE_WAIT_FANOUTS,
-                               RD_KAFKA_ADMIN_STATE_CONSTRUCT_REQUEST,
-                               RD_KAFKA_ADMIN_STATE_WAIT_RESPONSE,
-                               RD_KAFKA_ADMIN_STATE_WAIT_BROKER_LIST,
+                        enum {
+                                RD_KAFKA_ADMIN_STATE_INIT,
+                                RD_KAFKA_ADMIN_STATE_WAIT_BROKER,
+                                RD_KAFKA_ADMIN_STATE_WAIT_CONTROLLER,
+                                RD_KAFKA_ADMIN_STATE_WAIT_FANOUTS,
+                                RD_KAFKA_ADMIN_STATE_CONSTRUCT_REQUEST,
+                                RD_KAFKA_ADMIN_STATE_WAIT_RESPONSE,
+                                RD_KAFKA_ADMIN_STATE_WAIT_BROKER_LIST,
                         } state;
 
                         int32_t broker_id; /**< Requested broker id to
@@ -559,16 +560,18 @@ struct rd_kafka_op_s {
 
                 /**< Mock cluster command */
                 struct {
-                        enum { RD_KAFKA_MOCK_CMD_TOPIC_SET_ERROR,
-                               RD_KAFKA_MOCK_CMD_TOPIC_CREATE,
-                               RD_KAFKA_MOCK_CMD_PART_SET_LEADER,
-                               RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER,
-                               RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER_WMARKS,
-                               RD_KAFKA_MOCK_CMD_BROKER_SET_UPDOWN,
-                               RD_KAFKA_MOCK_CMD_BROKER_SET_RTT,
-                               RD_KAFKA_MOCK_CMD_BROKER_SET_RACK,
-                               RD_KAFKA_MOCK_CMD_COORD_SET,
-                               RD_KAFKA_MOCK_CMD_APIVERSION_SET,
+                        enum {
+                                RD_KAFKA_MOCK_CMD_TOPIC_SET_ERROR,
+                                RD_KAFKA_MOCK_CMD_TOPIC_CREATE,
+                                RD_KAFKA_MOCK_CMD_PART_SET_LEADER,
+                                RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER,
+                                RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER_WMARKS,
+                                RD_KAFKA_MOCK_CMD_BROKER_SET_UPDOWN,
+                                RD_KAFKA_MOCK_CMD_BROKER_SET_RTT,
+                                RD_KAFKA_MOCK_CMD_BROKER_SET_RACK,
+                                RD_KAFKA_MOCK_CMD_BROKER_DECOMMISSION,
+                                RD_KAFKA_MOCK_CMD_COORD_SET,
+                                RD_KAFKA_MOCK_CMD_APIVERSION_SET,
                         } cmd;
 
                         rd_kafka_resp_err_t err; /**< Error for:

--- a/tests/0145-broker-same-host-port.c
+++ b/tests/0145-broker-same-host-port.c
@@ -1,0 +1,89 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2023, Matt Fleming.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+
+int main_0145_broker_same_host_port(int argc, char **argv) {
+        rd_kafka_mock_cluster_t *cluster;
+        const char *bootstraps;
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        const rd_kafka_metadata_t *md;
+        rd_kafka_resp_err_t err;
+        const size_t num_brokers = 3;
+        size_t cnt               = 0;
+        int32_t *ids;
+        size_t i;
+
+        if (test_needs_auth()) {
+                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
+                return 0;
+        }
+
+        cluster = test_mock_cluster_new(num_brokers, &bootstraps);
+
+        for (i = 1; i <= num_brokers; i++) {
+                rd_kafka_mock_broker_set_host_port(cluster, i, "localhost",
+                                                   9092);
+        }
+
+        test_conf_init(&conf, NULL, 10);
+
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "debug", "mock,broker,metadata");
+
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        /* Trigger Metadata request which will update learned brokers. */
+        err = rd_kafka_metadata(rk, 0, NULL, &md, tmout_multip(5000));
+        rd_kafka_metadata_destroy(md);
+        TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+
+        ids = rd_kafka_broker_get_learned_ids(rk, &cnt);
+
+        TEST_ASSERT(cnt == num_brokers,
+                    "expected %" PRIusz " brokers in cache, not %" PRIusz,
+                    num_brokers, cnt);
+
+        for (i = 0; i < cnt; i++) {
+                /* Brokers are added at the head of the list. */
+                int32_t expected_id = cnt - i;
+
+                TEST_ASSERT(ids[i] == expected_id,
+                            "expected broker %d in cache, not %d", expected_id,
+                            ids[i]);
+        }
+
+        if (ids)
+                free(ids);
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(cluster);
+
+        return 0;
+}

--- a/tests/0146-purge-brokers.c
+++ b/tests/0146-purge-brokers.c
@@ -1,0 +1,112 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2023, Matt Fleming.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+
+static void fetch_metadata(rd_kafka_t *rk, size_t expected_num_brokers) {
+        const rd_kafka_metadata_t *md;
+        rd_kafka_resp_err_t err;
+        size_t cnt = 0;
+        int32_t *ids;
+        size_t i;
+        int timeout_secs = 5;
+        int64_t abs_timeout_us = test_clock() + timeout_secs * 1000000;
+
+        TEST_SAY("Waiting for up to %ds for metadata update\n", timeout_secs);
+
+        /* Trigger Metadata request which will update learned brokers. */
+        do {
+                err = rd_kafka_metadata(rk, 0, NULL, &md, tmout_multip(5000));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+                rd_kafka_metadata_destroy(md);
+
+                rd_sleep(1);
+
+                ids = rd_kafka_broker_get_learned_ids(rk, &cnt);
+        } while (test_clock() < abs_timeout_us && cnt < expected_num_brokers);
+
+        TEST_ASSERT(cnt == expected_num_brokers,
+                    "expected %" PRIusz " brokers in cache, not %" PRIusz,
+                    expected_num_brokers, cnt);
+
+        for (i = 0; i < cnt; i++) {
+                /* Brokers are added at the head of the list. */
+                int32_t expected_id = cnt - i;
+
+                TEST_ASSERT(ids[i] == expected_id,
+                            "expected broker %d in cache, not %d", expected_id,
+                            ids[i]);
+        }
+
+        if (ids)
+                free(ids);
+}
+
+
+int main_0146_purge_brokers(int argc, char **argv) {
+        rd_kafka_mock_cluster_t *cluster;
+        const char *bootstraps;
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        const size_t num_brokers = 3;
+
+        if (test_needs_auth()) {
+                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
+                return 0;
+        }
+
+        cluster = test_mock_cluster_new(num_brokers, &bootstraps);
+
+        test_conf_init(&conf, NULL, 10);
+
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "debug", "mock,broker,metadata");
+
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        fetch_metadata(rk, num_brokers);
+
+        /* Decommission a broker. */
+        TEST_ASSERT(rd_kafka_mock_broker_decommission(cluster, 3) == 0,
+                    "Failed to remove broker from cluster");
+
+        /*
+         * Wait for:
+         * - the broker to decommission
+         * - rd_kafka_1s_tmr_cb() to fire and establish a new broker connection
+         */
+        rd_sleep(3);
+
+        fetch_metadata(rk, num_brokers - 1);
+
+        rd_kafka_destroy(rk);
+        test_mock_cluster_destroy(cluster);
+
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ set(
     0142-reauthentication.c
     0143-exponential_backoff_mock.c
     0144-idempotence_mock.c
+    0145-brokers-same-host-port.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ set(
     0143-exponential_backoff_mock.c
     0144-idempotence_mock.c
     0145-brokers-same-host-port.c
+    0146-purge-brokers.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -258,6 +258,7 @@ _TEST_DECL(0142_reauthentication);
 _TEST_DECL(0143_exponential_backoff_mock);
 _TEST_DECL(0144_idempotence_mock);
 _TEST_DECL(0145_broker_same_host_port);
+_TEST_DECL(0146_purge_brokers);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -513,6 +514,7 @@ struct test tests[] = {
     _TEST(0143_exponential_backoff_mock, TEST_F_LOCAL),
     _TEST(0144_idempotence_mock, TEST_F_LOCAL, TEST_BRKVER(0, 11, 0, 0)),
     _TEST(0145_broker_same_host_port, 0),
+    _TEST(0146_purge_brokers, 0),
 
 
     /* Manual tests */

--- a/tests/test.c
+++ b/tests/test.c
@@ -257,6 +257,7 @@ _TEST_DECL(0140_commit_metadata);
 _TEST_DECL(0142_reauthentication);
 _TEST_DECL(0143_exponential_backoff_mock);
 _TEST_DECL(0144_idempotence_mock);
+_TEST_DECL(0145_broker_same_host_port);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -511,6 +512,7 @@ struct test tests[] = {
     _TEST(0142_reauthentication, 0, TEST_BRKVER(2, 2, 0, 0)),
     _TEST(0143_exponential_backoff_mock, TEST_F_LOCAL),
     _TEST(0144_idempotence_mock, TEST_F_LOCAL, TEST_BRKVER(0, 11, 0, 0)),
+    _TEST(0145_broker_same_host_port, 0),
 
 
     /* Manual tests */
@@ -983,7 +985,7 @@ static RD_INLINE unsigned int test_rand(void) {
 #ifdef _WIN32
         rand_s(&r);
 #else
-        r     = rand();
+        r = rand();
 #endif
         return r;
 }
@@ -1884,7 +1886,7 @@ int main(int argc, char **argv) {
 #ifdef _WIN32
                 pcwd = _getcwd(cwd, sizeof(cwd) - 1);
 #else
-                pcwd   = getcwd(cwd, sizeof(cwd) - 1);
+                pcwd = getcwd(cwd, sizeof(cwd) - 1);
 #endif
                 if (pcwd)
                         TEST_SAY("Current directory: %s\n", cwd);
@@ -5452,7 +5454,8 @@ void test_headers_dump(const char *what,
 
 
 /**
- * @brief Retrieve and return the list of broker ids in the cluster.
+ * @brief Retrieve and return the list of broker ids in the cluster by
+ *        sending a Metadata request.
  *
  * @param rk Optional instance to use.
  * @param cntp Will be updated to the number of brokers returned.

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -226,6 +226,7 @@
     <ClCompile Include="..\..\tests\0143-exponential_backoff_mock.c" />
     <ClCompile Include="..\..\tests\0144-idempotence_mock.c" />
     <ClCompile Include="..\..\tests\0145-brokers-same-host-port.c" />
+    <ClCompile Include="..\..\tests\0146-purge-brokers.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -225,6 +225,7 @@
     <ClCompile Include="..\..\tests\0142-reauthentication.c" />
     <ClCompile Include="..\..\tests\0143-exponential_backoff_mock.c" />
     <ClCompile Include="..\..\tests\0144-idempotence_mock.c" />
+    <ClCompile Include="..\..\tests\0145-brokers-same-host-port.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
Brokers that are not in the metadata should be purged from the internal client lists. This helps to avoid annoying "No route to host" and other connection failure messages.

Fixes #238